### PR TITLE
Ensure Example.inform/Build folder is created in git checkout

### DIFF
--- a/Workspace/T0/Example.inform/Build/.gitkeep
+++ b/Workspace/T0/Example.inform/Build/.gitkeep
@@ -1,0 +1,1 @@
+# Ensure this folder is created


### PR DESCRIPTION
The tests always fail for me the first time I run them because this folder
doesn't exist. This adds a dummy file, traditionally called .gitkeep, so
that git will create the folder on checkout.