### PR TITLE
Move to 32-bit character strings

### DIFF
--- a/Chapter 1/Basics.w
+++ b/Chapter 1/Basics.w
@@ -47,11 +47,11 @@ we need to use the equivalent of traditional |malloc| and |calloc| routines.
 @e TESTER_DA
 
 @<Declare new debugging log aspects@> =
-	Log::declare_aspect(VARIABLES_DA, L"variables", FALSE, FALSE);
-	Log::declare_aspect(INSTRUCTIONS_DA, L"instructions", FALSE, FALSE);
-	Log::declare_aspect(DIFFER_DA, L"differ", FALSE, FALSE);
-	Log::declare_aspect(HASHER_DA, L"hasher", FALSE, FALSE);
-	Log::declare_aspect(TESTER_DA, L"tester", FALSE, FALSE);
+	Log::declare_aspect(VARIABLES_DA, U"variables", FALSE, FALSE);
+	Log::declare_aspect(INSTRUCTIONS_DA, U"instructions", FALSE, FALSE);
+	Log::declare_aspect(DIFFER_DA, U"differ", FALSE, FALSE);
+	Log::declare_aspect(HASHER_DA, U"hasher", FALSE, FALSE);
+	Log::declare_aspect(TESTER_DA, U"tester", FALSE, FALSE);
 
 @h Writers and loggers.
 This enables the |%k| and |$L| format notations in |WRITE| and |LOG|

--- a/Chapter 1/Command Line Arguments.w
+++ b/Chapter 1/Command Line Arguments.w
@@ -30,34 +30,34 @@ and heading text in the normal Foundation way:
 
 @<Register some configuration switches with Foundation@> =
 	CommandLine::declare_heading(
-		L"This is intest, a command-line tool for testing command-line tools\n\n"
-		L"intest PROJECT OPTIONS -using RECIPEFILE -do INSTRUCTIONS\n\n"
-		L"PROJECT is the home folder of the project to be tested\n\n"
-		L"-using RECIPEFILE tells intest where to find test recipes: default\n"
-		L"is PROJECT/Tests/PROJECT.intest\n\n"
-		L"-do INSTRUCTIONS tells intest what to do with its tests:\n"
-		L"    ACTION CASE1 CASE2 ... performs the given action, which may be:\n"
-		L"    -test (default), -show, -curse, -bless, -rebless, -open, -show-i6\n"
-		L"    CASEs can be identified by name, or by 'all', 'cases', 'problems', etc.\n"
-		L"    a bare number as a CASE means this case number in the command history\n\n"
-		L"'intest ?' shows the command history; 'intest ?N' repeats command N from it\n\n"
-		L"OPTIONS are as follows:\n"
+		U"This is intest, a command-line tool for testing command-line tools\n\n"
+		U"intest PROJECT OPTIONS -using RECIPEFILE -do INSTRUCTIONS\n\n"
+		U"PROJECT is the home folder of the project to be tested\n\n"
+		U"-using RECIPEFILE tells intest where to find test recipes: default\n"
+		U"is PROJECT/Tests/PROJECT.intest\n\n"
+		U"-do INSTRUCTIONS tells intest what to do with its tests:\n"
+		U"    ACTION CASE1 CASE2 ... performs the given action, which may be:\n"
+		U"    -test (default), -show, -curse, -bless, -rebless, -open, -show-i6\n"
+		U"    CASEs can be identified by name, or by 'all', 'cases', 'problems', etc.\n"
+		U"    a bare number as a CASE means this case number in the command history\n\n"
+		U"'intest ?' shows the command history; 'intest ?N' repeats command N from it\n\n"
+		U"OPTIONS are as follows:\n"
 	);
 
-	CommandLine::declare_switch(PURGE_CLSW, L"purge", 1,
-		L"delete any extraneous files from the intest workspace on disc");
-	CommandLine::declare_switch(SET_CLSW, L"set", 2,
-		L"set a global variable, e.g., -set '$$magic = XYZZY'");
-	CommandLine::declare_boolean_switch(HISTORY_CLSW, L"history", 1,
-		L"use command history", TRUE);
-	CommandLine::declare_boolean_switch(COLOURS_CLSW, L"colours", 1,
-		L"show discrepancies in red and green using terminal emulation", TRUE);
-	CommandLine::declare_boolean_switch(VERBOSE_CLSW, L"verbose", 1,
-		L"print out all shell commands issued", FALSE);
-	CommandLine::declare_numerical_switch(THREADS_CLSW, L"threads", 1,
-		L"use X independent threads to test");
-	CommandLine::declare_numerical_switch(INTERNAL_CLSW, L"internal", 2,
-		L"use X as the internal Inform distribution resources");
+	CommandLine::declare_switch(PURGE_CLSW, U"purge", 1,
+		U"delete any extraneous files from the intest workspace on disc");
+	CommandLine::declare_switch(SET_CLSW, U"set", 2,
+		U"set a global variable, e.g., -set '$$magic = XYZZY'");
+	CommandLine::declare_boolean_switch(HISTORY_CLSW, U"history", 1,
+		U"use command history", TRUE);
+	CommandLine::declare_boolean_switch(COLOURS_CLSW, U"colours", 1,
+		U"show discrepancies in red and green using terminal emulation", TRUE);
+	CommandLine::declare_boolean_switch(VERBOSE_CLSW, U"verbose", 1,
+		U"print out all shell commands issued", FALSE);
+	CommandLine::declare_numerical_switch(THREADS_CLSW, U"threads", 1,
+		U"use X independent threads to test");
+	CommandLine::declare_numerical_switch(INTERNAL_CLSW, U"internal", 2,
+		U"use X as the internal Inform distribution resources");
 
 @ The following structure encodes a set of instructions from the user (probably
 from the command line) about what Intest should do on this run:
@@ -188,7 +188,7 @@ int Instructions::read_switches(intest_instructions *args,
 	for (int i=from_arg_n; i<to_arg_n; i++) {
 		text_stream *opt = argv[i];
 		text_stream *arg = NULL; if (i+1 < to_arg_n) arg = argv[i+1];
-		if (Regexp::match(&mr, opt, L"-+(%c*)")) {
+		if (Regexp::match(&mr, opt, U"-+(%c*)")) {
 			clf_reader_state crs;
 			crs.state = (void *) args; crs.f = &Instructions::respond; crs.g = NULL;
 			crs.subs = FALSE; crs.nrt = 0;
@@ -220,7 +220,7 @@ void Instructions::respond(int id, int val, text_stream *arg, void *state) {
 			return;
 		case SET_CLSW: {
 			match_results mr = Regexp::create_mr();
-			if (Regexp::match(&mr, arg, L" *([A-Z0-9_]+) *= *(%c*?) *")) {
+			if (Regexp::match(&mr, arg, U" *([A-Z0-9_]+) *= *(%c*?) *")) {
 				Globals::create(Str::duplicate(mr.exp[0]));
 				Globals::set(Str::duplicate(mr.exp[0]), Str::duplicate(mr.exp[1]));
 			} else {

--- a/Chapter 2/Actions.w
+++ b/Chapter 2/Actions.w
@@ -300,11 +300,11 @@ int Actions::identify_wildcard(text_stream *token) {
 	LOOP_THROUGH_TEXT(pos, token)
 		if (Str::get(pos) == '%')
 			return REGEXP_WILDCARD;
-	int c = Str::get_first_char(token);
+	inchar32_t c = Str::get_first_char(token);
 	if (c == ':') return GROUP_WILDCARD;
 	if (Str::len(token) == 1) {
-		if ((c >= 'A') && (c <= 'Z')) return c - 'A' + EXTENSION_WILDCARD_BASE;
-		if ((c >= 'a') && (c <= 'z')) return c - 'a' + EXTENSION_WILDCARD_BASE;
+		if ((c >= 'A') && (c <= 'Z')) return (int) c - 'A' + EXTENSION_WILDCARD_BASE;
+		if ((c >= 'a') && (c <= 'z')) return (int) c - 'a' + EXTENSION_WILDCARD_BASE;
 	}
 	if (Str::eq(token, I"all")) return ALL_WILDCARD;
 	if (Str::eq(token, I"examples")) return EXAMPLES_WILDCARD;
@@ -432,9 +432,9 @@ void Actions::perform(OUTPUT_STREAM, intest_instructions *args) {
 		match_results mr = Regexp::create_mr();
 		text_stream *key = NULL, *match = name;
 		int exactly = TRUE;
-		if (Regexp::match(&mr, name, L"$*(%C+) is (%c*)")) {
+		if (Regexp::match(&mr, name, U"$*(%C+) is (%c*)")) {
 			key = mr.exp[0]; match = mr.exp[1];
-		} else if (Regexp::match(&mr, name, L"$*(%C+) includes (%c*)")) {
+		} else if (Regexp::match(&mr, name, U"$*(%C+) includes (%c*)")) {
 			key = mr.exp[0]; match = mr.exp[1]; exactly = FALSE;
 		}
 		RecipeFiles::find_cases_matching(matches, args->search_path, key, match, exactly);
@@ -468,7 +468,7 @@ void Actions::perform(OUTPUT_STREAM, intest_instructions *args) {
 void Actions::read_group(text_stream *text, text_file_position *tfp, void *vm) {
 	linked_list *matches = (linked_list *) vm;
 	Str::trim_white_space(text);
-	wchar_t c = Str::get_first_char(text);
+	inchar32_t c = Str::get_first_char(text);
 	if ((c == 0) || (c == '#') || (c == '!')) return;
 	ADD_TO_LINKED_LIST(Str::duplicate(text), text_stream, matches);
 }
@@ -501,11 +501,11 @@ substitute in the case number for |[NUMBER]|, and similarly for |[NAME]|.
 	TEMPORARY_TEXT(leaf)
 	leaf = Str::duplicate(Filenames::get_leafname(F));
 	match_results mr = Regexp::create_mr();
-	while (Regexp::match(&mr, leaf, L"(%c*?)%[NAME%](%c*)")) {
+	while (Regexp::match(&mr, leaf, U"(%c*?)%[NAME%](%c*)")) {
 		Str::clear(leaf);
 		WRITE_TO(leaf, "%S%s%S", mr.exp[0], itc->test_case_name, mr.exp[1]);
 	}
-	while (Regexp::match(&mr, leaf, L"(%c*?)%[NUMBER%](%c*)")) {
+	while (Regexp::match(&mr, leaf, U"(%c*?)%[NUMBER%](%c*)")) {
 		Str::clear(leaf);
 		WRITE_TO(leaf, "%S%d%S", mr.exp[0], count, mr.exp[1]);
 	}

--- a/Chapter 2/Global Variables.w
+++ b/Chapter 2/Global Variables.w
@@ -77,7 +77,7 @@ void Globals::set(text_stream *name, text_stream *original) {
 
 @<Make substitutions@> =
 	match_results mr = Regexp::create_mr();
-	while (Regexp::match(&mr, value, L"(%c*)$$(%i+)(%c*)")) {
+	while (Regexp::match(&mr, value, U"(%c*)$$(%i+)(%c*)")) {
 		Str::copy(value, mr.exp[0]);
 		if (Dictionaries::find(globals_dictionary, mr.exp[1])) {
 			WRITE_TO(value, "%S", Globals::get(mr.exp[1]));

--- a/Chapter 2/Recipe Files.w
+++ b/Chapter 2/Recipe Files.w
@@ -43,7 +43,7 @@ with the routine parsing the command line. In any case, nobody will hit:
 	string_position pos = Str::start(line_text);
 	while (TRUE) {
 		while (Regexp::white_space(Str::get(pos))) pos = Str::forward(pos);
-		wchar_t c = Str::get(pos);
+		inchar32_t c = Str::get(pos);
 		if ((c == 0) || (c == '!')) break;
 
 		if (no_line_tokens == MAX_LINE_TOKENS) {
@@ -177,24 +177,24 @@ void RecipeFiles::read_using_instructions(intest_instructions *args,
 				allowed_to_execute?"yes":"no");
 		i++; continue;
 	}
-	if (Str::eq_wide_string(opt, L"-endif")) { allowed_to_execute = TRUE; continue; }
+	if (Str::eq_wide_string(opt, U"-endif")) { allowed_to_execute = TRUE; continue; }
 	if (allowed_to_execute == FALSE) continue;
 
 @<Act on set@> =
-	if ((Str::eq_wide_string(opt, L"-set")) && (i+2<to_arg_n)) {
+	if ((Str::eq_wide_string(opt, U"-set")) && (i+2<to_arg_n)) {
 		Globals::create(argv[i+1]);
 		Globals::set(argv[i+1], argv[i+2]);
 		i += 2; continue;
 	}
 
 @<Act on groups@> =
-	if ((Str::eq_wide_string(opt, L"-groups")) && (i+1<to_arg_n)) {
+	if ((Str::eq_wide_string(opt, U"-groups")) && (i+1<to_arg_n)) {
 		args->groups_folder = Pathnames::from_text(argv[i+1]);
 		i++; continue;
 	}
 
 @<Act on singular@> =
-	if ((Str::eq_wide_string(opt, L"-singular")) && (i+1<to_arg_n)) {
+	if ((Str::eq_wide_string(opt, U"-singular")) && (i+1<to_arg_n)) {
 		dictionary *D = args->singular_case_names;
 		WRITE_TO(Dictionaries::create_text(D, argv[i+1]), "1");
 		i++; continue;
@@ -316,7 +316,7 @@ text_stream *RecipeFiles::case_type_as_text(int spt) {
 =
 void RecipeFiles::expand(OUTPUT_STREAM, text_stream *from) {
 	match_results mr = Regexp::create_mr();
-	if (Regexp::match(&mr, from, L"%$%$([A-Za-z]+)(%c*)")) {
+	if (Regexp::match(&mr, from, U"%$%$([A-Za-z]+)(%c*)")) {
 		WRITE("%S%S", Globals::get(mr.exp[0]), mr.exp[1]);
 	} else {
 		WRITE("%S", from);
@@ -334,7 +334,7 @@ void RecipeFiles::scan_directory_for_cases(linked_list *L,
 	if (FOLD == NULL) Errors::fatal_with_path("unable to open test cases folder", P);
 	TEMPORARY_TEXT(leafname)
 	while (Directories::next(FOLD, leafname)) {
-		wchar_t first = Str::get_first_char(leafname), last = Str::get_last_char(leafname);
+		inchar32_t first = Str::get_first_char(leafname), last = Str::get_last_char(leafname);
 		if (Platform::is_folder_separator(last)) continue;
 		if (first == '.') continue;
 		if (first == '(') continue;
@@ -549,7 +549,7 @@ void RecipeFiles::find_cases_matching(linked_list *matches, linked_list *sources
 	} else {
 		WRITE_TO(re, "%%c*%S%%c*", match);
 	}
-	wchar_t wregexp[MAX_NAME_MATCH_LENGTH];
+	inchar32_t wregexp[MAX_NAME_MATCH_LENGTH];
 	Str::copy_to_wide_string(wregexp, re, MAX_NAME_MATCH_LENGTH);
 	DISCARD_TEXT(re)
 	match_results mr2 = Regexp::create_mr();

--- a/Chapter 2/The Extractor.w
+++ b/Chapter 2/The Extractor.w
@@ -98,7 +98,7 @@ double-quoted text, then that's the title for the test case.
 @<Consider entering extraction mode for PLAIN@> =
 	if (tfp->line_count == 1) {
 		match_results mr = Regexp::create_mr();
-		if ((Regexp::match(&mr, line, L"\"(%c*?)\" *")) && (es->tc)) {
+		if ((Regexp::match(&mr, line, U"\"(%c*?)\" *")) && (es->tc)) {
 			RecipeFiles::NameTestCase(es->tc, mr.exp[0]);
 			Regexp::dispose_of(&mr);
 		}
@@ -116,7 +116,7 @@ after the first line not matching this.
 					es->case_list, es->force_vm, es->to_use_recipe);
 		}
 		match_results mr = Regexp::create_mr();
-		if (Regexp::match(&mr, line, L"(%C+) *: *(%c*) *")) {
+		if (Regexp::match(&mr, line, U"(%C+) *: *(%c*) *")) {
 			text_stream *key = mr.exp[0], *value = mr.exp[1];
 			if (tfp->line_count == 1) {
 				if (Str::eq(key, I"Test") == FALSE) {
@@ -145,7 +145,7 @@ after the first line not matching this.
 					es->case_list, es->force_vm, es->to_use_recipe);
 		}
 		match_results mr = Regexp::create_mr();
-		if (Regexp::match(&mr, line, L"(%C+) *: *(%c*) *")) {
+		if (Regexp::match(&mr, line, U"(%C+) *: *(%c*) *")) {
 			text_stream *key = mr.exp[0], *value = mr.exp[1];
 			if (tfp->line_count == 1) {
 				if (Str::eq(key, I"Problem") == FALSE) {
@@ -181,13 +181,13 @@ the header:
 
 @<Consider entering extraction mode for EXAMPLE@> =
 	match_results mr = Regexp::create_mr();
-	if (Regexp::match(&mr, line, L"(%C+) *: *(%c*) *")) {
+	if (Regexp::match(&mr, line, U"(%C+) *: *(%c*) *")) {
 		text_stream *key = mr.exp[0], *value = mr.exp[1];
 		if (Str::eq(key, I"Example")) {
 			es->no_kv_pairs = 0;
 			es->skip_next = FALSE;
 			match_results mr2 = Regexp::create_mr();
-			if (Regexp::match(&mr2, line, L"(%C+) *: *(%*+) *(%c*) *")) {
+			if (Regexp::match(&mr2, line, U"(%C+) *: *(%*+) *(%c*) *")) {
 				es->stars = Str::duplicate(mr2.exp[1]);
 				es->title = Str::duplicate(mr2.exp[2]);
 			}
@@ -202,14 +202,14 @@ the header:
 	}
 	Regexp::dispose_of(&mr);
 	TEMPORARY_TEXT(line_content)
-	if ((Str::begins_with_wide_string(line, L"\t{*}")) && (es->skip_next == FALSE)) {
+	if ((Str::begins_with_wide_string(line, U"\t{*}")) && (es->skip_next == FALSE)) {
 		Str::copy_tail(line_content, line, 4);
 		if (es->examples_found++ == 0) {
 			Str::clear(line);
 			WRITE_TO(line, "\t%S", line_content);
 			match_results mr = Regexp::create_mr();
-			if (Regexp::match(&mr, line, L"%t\"(%c*?)\" *") ||
-				Regexp::match(&mr, line, L"%t\"(%c*?)\" *by *%c*") ) {
+			if (Regexp::match(&mr, line, U"%t\"(%c*?)\" *") ||
+				Regexp::match(&mr, line, U"%t\"(%c*?)\" *by *%c*") ) {
 				if (es->extractor_command == CENSUS_ACTION)
 					es->tc = RecipeFiles::observe_in_example(
 						es->case_list, es->force_vm, es->to_use_recipe);
@@ -231,7 +231,7 @@ the header:
 		}
 	}
 	if ((es->extraction_line_count > 0) &&
-		(Str::begins_with_wide_string(line, L"\t{**}"))) {
+		(Str::begins_with_wide_string(line, U"\t{**}"))) {
 		Str::copy_tail(line_content, line, 5);
 		if (es->examples_found == 1) {
 			Str::clear(line);
@@ -246,16 +246,16 @@ extension file. There can be more than one.
 
 @<Consider entering extraction mode for EXTENSION@> =
 	match_results mr = Regexp::create_mr();
-	if ((tfp->line_count == 1) && (Regexp::match(&mr, line, L"%c*for Glulx only%c*")))
+	if ((tfp->line_count == 1) && (Regexp::match(&mr, line, U"%c*for Glulx only%c*")))
 		es->force_vm = Str::new_from_ISO_string("G");
-	if (Regexp::match(&mr, line, L" *---- +DOCUMENTATION +---- *"))
+	if (Regexp::match(&mr, line, U" *---- +DOCUMENTATION +---- *"))
 		es->documentation_found = TRUE;
-	else if (Regexp::match(&mr, line, L" *---- +Documentation +---- *"))
+	else if (Regexp::match(&mr, line, U" *---- +Documentation +---- *"))
 		es->documentation_found = TRUE;
-	else if (Regexp::match(&mr, line, L" *---- +documentation +---- *"))
+	else if (Regexp::match(&mr, line, U" *---- +documentation +---- *"))
 		es->documentation_found = TRUE;
 	if (es->documentation_found) {
-		if (Regexp::match(&mr, line, L" *Example: *%c*")) {
+		if (Regexp::match(&mr, line, U" *Example: *%c*")) {
 			es->now_extracting = FALSE;
 			es->examples_found++;
 			es->about_to_extract = TRUE;
@@ -263,7 +263,7 @@ extension file. There can be more than one.
 				es->tc = RecipeFiles::observe_in_extension(es->case_list,
 					es->examples_found, es->force_vm, es->to_use_recipe);
 		}
-		if ((es->about_to_extract) && (Str::begins_with_wide_string(line, L"\t*:"))) {
+		if ((es->about_to_extract) && (Str::begins_with_wide_string(line, U"\t*:"))) {
 			es->about_to_extract = FALSE;
 			int i = 3;
 			while (Regexp::white_space(Str::get_at(line, i))) i++;
@@ -271,8 +271,8 @@ extension file. There can be more than one.
 			Str::copy_tail(ext_eg, line, i);
 			if ((es->extractor_command == CENSUS_ACTION) ||
 				(es->examples_found == es->seek_ref)) {
-				if (Regexp::match(&mr, ext_eg, L"\"(%c*?)\" *") ||
-					Regexp::match(&mr, ext_eg, L"\"(%c*?)\" *by *%c*")) {
+				if (Regexp::match(&mr, ext_eg, U"\"(%c*?)\" *") ||
+					Regexp::match(&mr, ext_eg, U"\"(%c*?)\" *by *%c*")) {
 					if (es->tc) {
 						RecipeFiles::NameTestCase(es->tc, mr.exp[0]);
 					}
@@ -337,9 +337,9 @@ or "Use command line echoing" sentence.
 
 @<Perform a SOURCE on the line@> =
 	if ((text) && (es->tc)) {
-		if (Regexp::match(&mr, text, L"%c*Test me with \"%c*"))
+		if (Regexp::match(&mr, text, U"%c*Test me with \"%c*"))
 			es->tc->test_me_detected = TRUE;
-		if (Regexp::match(&mr, text, L"%c*Use command line echoing%c*"))
+		if (Regexp::match(&mr, text, U"%c*Use command line echoing%c*"))
 			es->tc->command_line_echoing_detected = TRUE;
 		WRITE_TO(es->DEST, "%S\n", text);
 	} else if (text) WRITE_TO(es->DEST, "%S\n", text);
@@ -350,13 +350,13 @@ sentence. Again, useful only for Inform 7.
 
 @<Perform a SCRIPT on the line@> =
 	if (text) {
-		if (Regexp::match(&mr, text, L"Test me with \"(%c*?)\"%c*")) {
+		if (Regexp::match(&mr, text, U"Test me with \"(%c*?)\"%c*")) {
 			Extractor::script_out(es->DEST, mr.exp[0]);
-		} else if (Regexp::match(&mr, text, L"Test me with \"(%c*?)")) {
+		} else if (Regexp::match(&mr, text, U"Test me with \"(%c*?)")) {
 			Extractor::script_out(es->DEST, mr.exp[0]);
 			es->continue_script = TRUE;
 		} else if (es->continue_script) {
-			if (Regexp::match(&mr, text, L"(%c*?)\"%c*?")) {
+			if (Regexp::match(&mr, text, U"(%c*?)\"%c*?")) {
 				Extractor::script_out(es->DEST, mr.exp[0]);
 				es->continue_script = FALSE;
 			} else Extractor::script_out(es->DEST, text);
@@ -378,7 +378,7 @@ void Extractor::script_out(OUTPUT_STREAM, text_stream *from) {
 	TEMPORARY_TEXT(script)
 	Str::copy(script, from);
 	match_results mr = Regexp::create_mr();
-	while (Regexp::match(&mr, script, L"(%c+?) */ *(%c*)")) {
+	while (Regexp::match(&mr, script, U"(%c+?) */ *(%c*)")) {
 		if (Str::len(mr.exp[0]) > 0) WRITE("%S\n", mr.exp[0]);
 		Str::copy(script, mr.exp[1]);
 	}

--- a/Chapter 2/The Historian.w
+++ b/Chapter 2/The Historian.w
@@ -116,14 +116,14 @@ void Historian::research(filename *H, int *argc, text_stream ***argv) {
 @<Substitute preset case numbers@> =
 	match_results mr = Regexp::create_mr();
 	for (int i=1; i<*argc; i++)
-		if (Regexp::match(&mr, (*argv)[i], L"%d+"))
+		if (Regexp::match(&mr, (*argv)[i], U"%d+"))
 			expands = TRUE;
 	if (expands) {
 		text_stream **new_argv =
 			Memory::calloc(*argc, sizeof(text_stream *), COMMAND_HISTORY_MREASON);
 		for (int i=0; i<*argc; i++) {
 			text_stream *p = (*argv)[i];
-			if ((i>0) && (Regexp::match(&mr, p, L"%d+"))) {
+			if ((i>0) && (Regexp::match(&mr, p, U"%d+"))) {
 				int f = Str::atoi(p, 0);
 				if ((f > 0) && (f <= no_preset_cases))
 					new_argv[i] = preset_cases[f-1];
@@ -144,7 +144,7 @@ void Historian::read_history_file(filename *H, int display_mode) {
 void Historian::read(text_stream *line_text, text_file_position *tfp, void *dmp) {
 	int display_mode = *((int *) dmp);
 	match_results mr = Regexp::create_mr();
-	if (Regexp::match(&mr, line_text, L"%?(%d+). (%c*)")) {
+	if (Regexp::match(&mr, line_text, U"%?(%d+). (%c*)")) {
 		TEMPORARY_TEXT(epoch_text)
 		TEMPORARY_TEXT(command_text)
 		Str::copy(epoch_text, mr.exp[0]);
@@ -154,7 +154,7 @@ void Historian::read(text_stream *line_text, text_file_position *tfp, void *dmp)
 		hm->epoch = Str::atoi(epoch_text, 0);
 		if (hm->epoch >= present_epoch) present_epoch = hm->epoch + 1;
 		hm->token_list = NEW_LINKED_LIST(text_stream);
-		while (Regexp::match(&mr, command_text, L"(%C+) *(%c*)")) {
+		while (Regexp::match(&mr, command_text, U"(%C+) *(%c*)")) {
 			text_stream *tok = Str::duplicate(mr.exp[0]);
 			ADD_TO_LINKED_LIST(tok, text_stream, hm->token_list);
 			Str::copy(command_text, mr.exp[1]);
@@ -164,7 +164,7 @@ void Historian::read(text_stream *line_text, text_file_position *tfp, void *dmp)
 		DISCARD_TEXT(epoch_text)
 		DISCARD_TEXT(command_text)
 	}
-	if (Regexp::match(&mr, line_text, L"(%d+) = *(%c*)"))
+	if (Regexp::match(&mr, line_text, U"(%d+) = *(%c*)"))
 		if (no_preset_cases < MAX_PRESET_CASES)
 			preset_cases[no_preset_cases++] = Str::duplicate(mr.exp[1]);
 	Regexp::dispose_of(&mr);

--- a/Chapter 3/Skeins.w
+++ b/Chapter 3/Skeins.w
@@ -174,7 +174,7 @@ status line early in play. We don't want that.
 @<Read from plain text@> =
 	Skeins::new_node(sks, tfp->line_count+1, NULL, sks->detected_format);
 	match_results mr = Regexp::create_mr();
-	while (Regexp::match(&mr, line_text, L"(%c*?)[/\\]T%d+[/\\](%c*)")) {
+	while (Regexp::match(&mr, line_text, U"(%c*?)[/\\]T%d+[/\\](%c*)")) {
 		Str::clear(line_text);
 		WRITE_TO(line_text, "Txx/%S", mr.exp[1]);
 	}
@@ -245,7 +245,7 @@ file, |<item nodeId="...">| is what declares a node ID, and it's now easy
 to match for that:
 
 @<Extract the node ID, if this line declares one@> =
-	if (Regexp::match(&mr, line_text, L"<item nodeId=\"(%c*)\">"))
+	if (Regexp::match(&mr, line_text, U"<item nodeId=\"(%c*)\">"))
 		Str::copy(sks->current_node, mr.exp[0]);
 
 @ Sometimes the I7 app wants us to make a skein from the whole file, and
@@ -253,18 +253,18 @@ sometimes just from a single node in it. Either way, this is run when
 we are at a node whose contents we care about:
 
 @<We want this node@> =
-	if (Regexp::match(&mr, line_text, L"<command %c*>"))
+	if (Regexp::match(&mr, line_text, U"<command %c*>"))
 		Str::put_at(sks->next_label, 0, 1);
-	if ((Regexp::match(&mr, line_text, L"<result %c*>")) && (sks->actual_flag)) {
+	if ((Regexp::match(&mr, line_text, U"<result %c*>")) && (sks->actual_flag)) {
 		Skeins::new_node(sks, -1, sks->next_label, sks->detected_format);
 		return;
 	}
-	if ((Regexp::match(&mr, line_text, L"<commentary %c*>")) && (sks->actual_flag == FALSE)) {
+	if ((Regexp::match(&mr, line_text, U"<commentary %c*>")) && (sks->actual_flag == FALSE)) {
 		Skeins::new_node(sks, -1, sks->next_label, sks->detected_format);
 		return;
 	}
-	if ((Regexp::match(&mr, line_text, L"</result%c*>")) ||
-		(Regexp::match(&mr, line_text, L"</commentary%c*>"))) {
+	if ((Regexp::match(&mr, line_text, U"</result%c*>")) ||
+		(Regexp::match(&mr, line_text, U"</commentary%c*>"))) {
 		if (sks->writing_to) Skeins::flush(sks);
 		sks->writing_to = NULL;
 		return;
@@ -289,14 +289,14 @@ the problem name and label the Skein node with it.
 
 @<Read from Inform 7 console output@> =
 	match_results mr = Regexp::create_mr();
-	if (Regexp::match(&mr, line_text, L"Inform 7 has finished%c*")) {
+	if (Regexp::match(&mr, line_text, U"Inform 7 has finished%c*")) {
 		if (sks->writing_to) Skeins::flush(sks);
 		sks->writing_to = NULL;
 		Regexp::dispose_of(&mr);
 		return;
 	}
-	if (Regexp::match(&mr, line_text, L"%c*Offending filename%c*")) return;
-	if (Regexp::match(&mr, line_text, L"Problem__ (%c*)")) {
+	if (Regexp::match(&mr, line_text, U"%c*Offending filename%c*")) return;
+	if (Regexp::match(&mr, line_text, U"Problem__ (%c*)")) {
 		Skeins::new_node(sks, -1, mr.exp[0], sks->detected_format);
 		Regexp::dispose_of(&mr);
 		return;
@@ -305,20 +305,20 @@ the problem name and label the Skein node with it.
 
 @<Read from Inform 6 console output@> =
 	match_results mr = Regexp::create_mr();
-	if (Regexp::match(&mr, line_text, L"Inform %C%C%C%C (%C+ %C+ %C%C%C%C)")) {
+	if (Regexp::match(&mr, line_text, U"Inform %C%C%C%C (%C+ %C+ %C%C%C%C)")) {
 		if (sks->writing_to) Skeins::flush(sks);
 		sks->writing_to = NULL;
 		Regexp::dispose_of(&mr);
 		return;
 	}
-	if (Regexp::match(&mr, line_text, L"(%c*) %(%C+ seconds%) *")) {
+	if (Regexp::match(&mr, line_text, U"(%c*) %(%C+ seconds%) *")) {
 		Str::clear(line_text);
 		WRITE_TO(line_text, "%S", mr.exp[0]);
 	}
 	Regexp::dispose_of(&mr);
 
 @<Read from a Frotz transcript@> =
-	wchar_t la[6];
+	inchar32_t la[6];
 	Str::copy_to_wide_string(la, line_text, 6);
 	if ((tfp->line_count == 1) && (la[0] == 0)) return;
 	if ((tfp->line_count == 2) && (la[0] == 'E') &&
@@ -331,14 +331,14 @@ the problem name and label the Skein node with it.
 	if (la[0] == '>') return;
 
 	match_results mr = Regexp::create_mr();
-	if (Regexp::match(&mr, line_text, L" %[quitting the game%]%c*")) {
+	if (Regexp::match(&mr, line_text, U" %[quitting the game%]%c*")) {
 		Regexp::dispose_of(&mr);
 		return;
 	}
 
 	if ((la[0] == ' ') && (la[1] == ' ') && (la[2] == '>') && (la[3] == '[')) {
 		match_results mr = Regexp::create_mr();
-		if (Regexp::match(&mr, line_text, L"%c%c%c%c%d+%] (%c+)")) {
+		if (Regexp::match(&mr, line_text, U"%c%c%c%c%d+%] (%c+)")) {
 			TEMPORARY_TEXT(label)
 			WRITE_TO(label, "reply to \"%S\"", mr.exp[0]);
 			Skeins::new_node(sks, -1, label, sks->detected_format);
@@ -360,25 +360,25 @@ the problem name and label the Skein node with it.
 	}
 
 @<Read from a Glulxe transcript@> =
-	wchar_t la[6];
+	inchar32_t la[6];
 	Str::copy_to_wide_string(la, line_text, 6);
 	if (sks->writing_to == NULL)
 		Skeins::new_node(sks, -1,
 			Str::new_from_ISO_string("opening text"), sks->detected_format);
 
 	match_results mr = Regexp::create_mr();
-	if (Regexp::match(&mr, line_text, L">Are you sure you want to quit?%c*")) {
+	if (Regexp::match(&mr, line_text, U">Are you sure you want to quit?%c*")) {
 		Regexp::dispose_of(&mr);
 		return;
 	}
 
-	if (Regexp::match(&mr, line_text, L">%(Testing.%)%c*")) {
+	if (Regexp::match(&mr, line_text, U">%(Testing.%)%c*")) {
 		Regexp::dispose_of(&mr);
 		break;
 	}
 
 	if ((la[0] == '>') && (la[1] == '[') &&
-		(Regexp::match(&mr, line_text, L"%c%c%d+%] (%c+)"))) {
+		(Regexp::match(&mr, line_text, U"%c%c%d+%] (%c+)"))) {
 		TEMPORARY_TEXT(label)
 		WRITE_TO(label, "reply to \"%S\"", mr.exp[0]);
 		Skeins::new_node(sks, -1, label, sks->detected_format);
@@ -418,7 +418,7 @@ Otherwise, we simply add the new line to the current turn buffer.
 void Skeins::remove_XML_escapes(OUTPUT_STREAM, text_stream *F) {
 	int L = Str::len(F);
 	for (int i = 0; i < L; i++) {
-		wchar_t la[6];
+		inchar32_t la[6];
 		Str::copy_to_wide_string(la, F, 6);
 
 		if ((la[0] == '&') && (la[1] == 'l') && (la[2] == 't') && (la[3] == ';')) {

--- a/Chapter 3/The Differ.w
+++ b/Chapter 3/The Differ.w
@@ -124,7 +124,7 @@ void Differ::print_edit_list_as_HTML(OUTPUT_STREAM, linked_list *L, text_stream 
 
 void Differ::print_fragment_as_HTML(OUTPUT_STREAM, text_stream *original) {
 	LOOP_THROUGH_TEXT(pos, original) {
-		wchar_t c = Str::get(pos);
+		inchar32_t c = Str::get(pos);
 		switch (c) {
 			case '<': WRITE("&lt;"); break;
 			case '>': WRITE("&gt;"); break;
@@ -188,7 +188,7 @@ banner, followed by a diff of the after-texts.
 
 @<If both texts contain the Inform banner version line, diff around that@> =
 	match_results mr = Regexp::create_mr();
-	wchar_t *template = L"(%c*?)(Release %d+ / Serial number %d+ / Inform %c+?\n)%c*";
+	inchar32_t *template = U"(%c*?)(Release %d+ / Serial number %d+ / Inform %c+?\n)%c*";
 	if (Regexp::match(&mr, A, template)) {
 		string_position A_ver = Str::plus(A_from, Str::len(mr.exp[0])); /* at the R in "Release" */
 		string_position A_post = Str::plus(A_ver, Str::len(mr.exp[1])); /* after version line ends */
@@ -295,7 +295,7 @@ run of slashes from that point. As a result, |///| does not match |////|, but
 			(Str::index(B_after_prefix) < Str::index(B_to));
 		A_after_prefix = Str::forward(A_after_prefix),
 		B_after_prefix = Str::forward(B_after_prefix)) {
-			wchar_t a = Str::get(A_after_prefix), b = Str::get(B_after_prefix);
+			inchar32_t a = Str::get(A_after_prefix), b = Str::get(B_after_prefix);
 			if (a == b) continue;
 			if (((a == '/') && (b == '\\')) || ((a == '\\') && (b == '/'))) {
 				while ((Str::get(A_after_prefix) == '/') || (Str::get(A_after_prefix) == '\\')) 
@@ -345,7 +345,7 @@ of a whole word.
 		(Str::index(B_suffix) > Str::index(B_from));
 		A_suffix = Str::back(A_suffix),
 		B_suffix = Str::back(B_suffix)) {
-			wchar_t a = Str::get(Str::back(A_suffix)), b = Str::get(Str::back(B_suffix));
+			inchar32_t a = Str::get(Str::back(A_suffix)), b = Str::get(Str::back(B_suffix));
 			if (a == b) continue;
 			if (((a == '/') && (b == '\\')) || ((a == '\\') && (b == '/'))) {
 				while ((Str::get(Str::back(A_suffix)) == '/') || (Str::get(Str::back(A_suffix)) == '\\')) 
@@ -423,7 +423,7 @@ a version of |isalpha| which respects Unicode, or else the above algorithm
 will sometimes show edits mid-word at accented letters.
 
 =
-int Differ::boundary(wchar_t c, wchar_t d) {
+int Differ::boundary(inchar32_t c, inchar32_t d) {
 	if ((Characters::isalpha(c)) && (Characters::isalpha(d))) return FALSE;
 	return TRUE;
 }

--- a/Chapter 3/The Hasher.w
+++ b/Chapter 3/The Hasher.w
@@ -38,7 +38,7 @@ void Hasher::read_hash(text_stream *V, filename *F) {
 
 void Hasher::detect_hash(text_stream *line_text, text_file_position *tfp, void *vto) {
 	match_results mr = Regexp::create_mr();
-	if (Regexp::match(&mr, line_text, L" *(%C+) *"))
+	if (Regexp::match(&mr, line_text, U" *(%C+) *"))
 		Str::copy((text_stream *) vto, mr.exp[0]);
 	Regexp::dispose_of(&mr);
 }
@@ -57,7 +57,7 @@ void Hasher::read_hashes(intest_instructions *args) {
 void Hasher::detect_hashes(text_stream *line_text, text_file_position *tfp, void *vargs) {
 	intest_instructions *args = (intest_instructions *) vargs;
 	match_results mr = Regexp::create_mr();
-	if (Regexp::match(&mr, line_text, L"(%c*?) = (%C+)%c*")) {
+	if (Regexp::match(&mr, line_text, U"(%c*?) = (%C+)%c*")) {
 		test_case *tc = RecipeFiles::find_case(args, mr.exp[0]);
 		if (tc) Hasher::assign_to_case(tc, mr.exp[1]);
 	}

--- a/Chapter 3/The Reporter.w
+++ b/Chapter 3/The Reporter.w
@@ -65,22 +65,22 @@ void Reporter::filter(text_stream *line_text, text_file_position *tfp, void *vrs
 	report_state *rs = vrs;
 	text_stream *OUT = rs->REPORT_TO;
 	match_results mr = Regexp::create_mr();
-	if (Regexp::match(&mr, line_text, L" <!--CONTENT BEGINS-->")) {
+	if (Regexp::match(&mr, line_text, U" <!--CONTENT BEGINS-->")) {
 		WRITE("<!--INTEST REPORT BEGINS-->\n");
 		rs->stage = 2;
 	}
-	else if (Regexp::match(&mr, line_text, L" <!--BANNER BEGINS-->")) rs->stage = 3;
-	else if (Regexp::match(&mr, line_text, L" <!--HEADING BEGINS-->")) {
+	else if (Regexp::match(&mr, line_text, U" <!--BANNER BEGINS-->")) rs->stage = 3;
+	else if (Regexp::match(&mr, line_text, U" <!--HEADING BEGINS-->")) {
 		rs->stage = 4;
 		@<Insert test report header@>;
-	} else if (Regexp::match(&mr, line_text, L" <!--HEADING ENDS-->")) rs->stage = 5;
-	else if (Regexp::match(&mr, line_text, L" <!--BANNER ENDS-->")) rs->stage = 6;
-	else if (Regexp::match(&mr, line_text, L" <!--PROBLEMS BEGIN-->")) {
+	} else if (Regexp::match(&mr, line_text, U" <!--HEADING ENDS-->")) rs->stage = 5;
+	else if (Regexp::match(&mr, line_text, U" <!--BANNER ENDS-->")) rs->stage = 6;
+	else if (Regexp::match(&mr, line_text, U" <!--PROBLEMS BEGIN-->")) {
 		rs->stage = 7;
 		@<Insert additional material@>;
 	}
-	else if (Regexp::match(&mr, line_text, L" <!--PROBLEMS END-->")) rs->stage = 8;
-	else if (Regexp::match(&mr, line_text, L" <!--CONTENT ENDS-->")) {
+	else if (Regexp::match(&mr, line_text, U" <!--PROBLEMS END-->")) rs->stage = 8;
+	else if (Regexp::match(&mr, line_text, U" <!--CONTENT ENDS-->")) {
 		rs->stage = 9;
 		@<Insert test report footer@>;
 		WRITE("<!--INTEST REPORT ENDS-->\n");
@@ -230,8 +230,8 @@ void Reporter::combine_filter(text_stream *line_text, text_file_position *tfp, v
 	report_state *rs = vrs;
 	text_stream *OUT = rs->REPORT_TO;
 	match_results mr = Regexp::create_mr();
-	if (Regexp::match(&mr, line_text, L"<!--INTEST REPORT BEGINS-->")) rs->stage = 2;
-	else if (Regexp::match(&mr, line_text, L"<!--INTEST REPORT ENDS-->")) rs->stage = 3;
+	if (Regexp::match(&mr, line_text, U"<!--INTEST REPORT BEGINS-->")) rs->stage = 2;
+	else if (Regexp::match(&mr, line_text, U"<!--INTEST REPORT ENDS-->")) rs->stage = 3;
 	else if (((rs->stage == 1) && (rs->first_flag)) || ((rs->stage == 3) && (rs->last_flag)))
 		WRITE("%S\n", line_text);
 	else if (rs->stage == 2) {

--- a/Chapter 4/The Delia Compiler.w
+++ b/Chapter 4/The Delia Compiler.w
@@ -45,46 +45,46 @@ set of commands, enumerated as follows.
 =
 typedef struct recipe_command {
 	int rc_code; /* one of the |*_RCOM| codes below */
-	wchar_t *keyword;
+	inchar32_t *keyword;
 	int tokens_required; /* or negative for "any number, including none" */
 	int supports_or; /* an |or:| command can follow */
 	int changes_nesting;
 } recipe_command;
 
 recipe_command instruction_set[] = {
-	{ COPY_RCOM, L"copy", 2, FALSE, 0 },
-	{ DEBUGGER_RCOM, L"debugger", -1, TRUE, 0 },
-	{ DEFAULT_RCOM, L"default", -1, FALSE, 0 },
-	{ ELSE_RCOM, L"else", 0, FALSE, 0 },
-	{ ENDIF_RCOM, L"endif", 0, FALSE, -1 },
-	{ EXISTS_RCOM, L"exists", 1, TRUE, 0 },
-	{ EXTRACT_RCOM, L"extract", 2, FALSE, 0 },
-	{ FAIL_RCOM, L"fail", -1, FALSE, 0 },
-	{ FAIL_STEP_RCOM, L"fail step", -1, TRUE, 0 },
-	{ HASH_RCOM, L"hash", 1, TRUE, 0 },
-	{ IF_RCOM, L"if", 2, FALSE, 1 },
-	{ IFDEF_RCOM, L"ifdef", 1, FALSE, 1 },
-	{ IFNDEF_RCOM, L"ifndef", 1, FALSE, 1 },
-	{ IFFAIL_RCOM, L"iffail", 0, FALSE, 1 },
-	{ IFPASS_RCOM, L"ifpass", 0, FALSE, 1 },
-	{ IF_COMPATIBLE_RCOM, L"if compatible", 2, FALSE, 1 },
-	{ IF_EXISTS_RCOM, L"if exists", 1, FALSE, 1 },
-	{ IF_FORMAT_VALID_RCOM, L"if format valid", 1, FALSE, 1 },
-	{ IF_SHOWING_RCOM, L"if showing", 1, FALSE, 1 },
-	{ MATCH_BINARY_RCOM, L"match binary", 2, TRUE, 0 },
-	{ MATCH_FOLDER_RCOM, L"match folder", 2, TRUE, 0 },
-	{ MATCH_G_TRANSCRIPT_RCOM, L"match glulxe transcript", 2, TRUE, 0 },
-	{ MATCH_I6_TRANSCRIPT_RCOM, L"match i6 transcript", 2, TRUE, 0 },
-	{ MATCH_PROBLEM_RCOM, L"match problem", 2, TRUE, 0 },
-	{ MATCH_TEXT_RCOM, L"match text", 2, TRUE, 0 },
-	{ MATCH_PLATFORM_TEXT_RCOM, L"match platform text", 2, TRUE, 0 },
-	{ MATCH_Z_TRANSCRIPT_RCOM, L"match frotz transcript", 2, TRUE, 0 },
-	{ MKDIR_RCOM, L"mkdir", 1, FALSE, 0 },
-	{ OR_RCOM, L"or", -1, FALSE, 0 },
-	{ PASS_RCOM, L"pass", 1, FALSE, 0 },
-	{ SET_RCOM, L"set", -1, FALSE, 0 },
-	{ SHOW_RCOM, L"show", -1, TRUE, 0 },
-	{ STEP_RCOM, L"step", -1, TRUE, 0 },
+	{ COPY_RCOM, U"copy", 2, FALSE, 0 },
+	{ DEBUGGER_RCOM, U"debugger", -1, TRUE, 0 },
+	{ DEFAULT_RCOM, U"default", -1, FALSE, 0 },
+	{ ELSE_RCOM, U"else", 0, FALSE, 0 },
+	{ ENDIF_RCOM, U"endif", 0, FALSE, -1 },
+	{ EXISTS_RCOM, U"exists", 1, TRUE, 0 },
+	{ EXTRACT_RCOM, U"extract", 2, FALSE, 0 },
+	{ FAIL_RCOM, U"fail", -1, FALSE, 0 },
+	{ FAIL_STEP_RCOM, U"fail step", -1, TRUE, 0 },
+	{ HASH_RCOM, U"hash", 1, TRUE, 0 },
+	{ IF_RCOM, U"if", 2, FALSE, 1 },
+	{ IFDEF_RCOM, U"ifdef", 1, FALSE, 1 },
+	{ IFNDEF_RCOM, U"ifndef", 1, FALSE, 1 },
+	{ IFFAIL_RCOM, U"iffail", 0, FALSE, 1 },
+	{ IFPASS_RCOM, U"ifpass", 0, FALSE, 1 },
+	{ IF_COMPATIBLE_RCOM, U"if compatible", 2, FALSE, 1 },
+	{ IF_EXISTS_RCOM, U"if exists", 1, FALSE, 1 },
+	{ IF_FORMAT_VALID_RCOM, U"if format valid", 1, FALSE, 1 },
+	{ IF_SHOWING_RCOM, U"if showing", 1, FALSE, 1 },
+	{ MATCH_BINARY_RCOM, U"match binary", 2, TRUE, 0 },
+	{ MATCH_FOLDER_RCOM, U"match folder", 2, TRUE, 0 },
+	{ MATCH_G_TRANSCRIPT_RCOM, U"match glulxe transcript", 2, TRUE, 0 },
+	{ MATCH_I6_TRANSCRIPT_RCOM, U"match i6 transcript", 2, TRUE, 0 },
+	{ MATCH_PROBLEM_RCOM, U"match problem", 2, TRUE, 0 },
+	{ MATCH_TEXT_RCOM, U"match text", 2, TRUE, 0 },
+	{ MATCH_PLATFORM_TEXT_RCOM, U"match platform text", 2, TRUE, 0 },
+	{ MATCH_Z_TRANSCRIPT_RCOM, U"match frotz transcript", 2, TRUE, 0 },
+	{ MKDIR_RCOM, U"mkdir", 1, FALSE, 0 },
+	{ OR_RCOM, U"or", -1, FALSE, 0 },
+	{ PASS_RCOM, U"pass", 1, FALSE, 0 },
+	{ SET_RCOM, U"set", -1, FALSE, 0 },
+	{ SHOW_RCOM, U"show", -1, TRUE, 0 },
+	{ STEP_RCOM, U"step", -1, TRUE, 0 },
 	{ -1, NULL, 0, FALSE, 0 }
 };
 
@@ -181,13 +181,13 @@ tokens. The divider is a colon, which is optional (in which case, no tokens).
 void Delia::compile_line(text_stream *text, text_file_position *tfp, void *state) {
 	recipe *R = (recipe *) state;
 	match_results mr = Regexp::create_mr();
-	if ((Regexp::string_is_white_space(text)) || (Regexp::match(&mr, text, L" *!%c*"))) {
+	if ((Regexp::string_is_white_space(text)) || (Regexp::match(&mr, text, U" *!%c*"))) {
 		;
-	} else if (Regexp::match(&mr, text, L" *-end *")) {
+	} else if (Regexp::match(&mr, text, U" *-end *")) {
 		R->end_found = TRUE;
-	} else if (Regexp::match(&mr, text, L" *(%c*?): *(%c*)")) {
+	} else if (Regexp::match(&mr, text, U" *(%c*?): *(%c*)")) {
 		Delia::compile_command(R, text, mr.exp[0], mr.exp[1], tfp);
-	} else if (Regexp::match(&mr, text, L" *(%c*?)")) {
+	} else if (Regexp::match(&mr, text, U" *(%c*?)")) {
 		Delia::compile_command(R, text, mr.exp[0], Str::new(), tfp);
 	}
 	Regexp::dispose_of(&mr);
@@ -353,7 +353,7 @@ void Delia::compile_command(recipe *R, text_stream *text,
 			text_stream *K = first->token_text;
 			int bad = FALSE;
 			LOOP_THROUGH_TEXT(pos, K) {
-				wchar_t c = Str::get(pos);
+				inchar32_t c = Str::get(pos);
 				if (((c < 'a') || (c > 'z')) && ((c < '0') || (c > '9')) && (c != '-'))
 					bad = TRUE;
 			}
@@ -394,7 +394,7 @@ string at white space boundaries, except within the shell quote character.
 void Delia::tokenise(linked_list *L, text_stream *txt) {
 	string_position P = Str::start(txt);
 	while (Characters::is_space_or_tab(Str::get(P))) P = Str::forward(P);
-	wchar_t first = Str::get(P);
+	inchar32_t first = Str::get(P);
 	if (first == 0) return;
 
 	recipe_token *T = CREATE(recipe_token);

--- a/Chapter 4/The Tester.w
+++ b/Chapter 4/The Tester.w
@@ -139,7 +139,7 @@ and it's one that we are always executing.
 	WRITE_TO(recipe_name, "%S", tc->test_recipe_name);
 	int stipulating = FALSE;
 	for (int i=0; i<Str::len(tc->test_recipe_name); i++) {
-		wchar_t c = Str::get_at(tc->test_recipe_name, i);
+		inchar32_t c = Str::get_at(tc->test_recipe_name, i);
 		if (c == ':') {
 			if (stipulating == FALSE) {
 				Str::put_at(recipe_name, i, ']');
@@ -219,7 +219,7 @@ and it's one that we are always executing.
 @<Add a stipulation@> =
 	if (Str::len(stipulation) > 0) {
 		match_results mr = Regexp::create_mr();
-		if (Regexp::match(&mr, stipulation, L" *(%C+) *= *(%c*?) *")) {
+		if (Regexp::match(&mr, stipulation, U" *(%C+) *= *(%c*?) *")) {
 			text_stream *key = mr.exp[0];
 			text_stream *value = mr.exp[1];
 			Tester::populate(D, key, value);
@@ -345,7 +345,7 @@ dictionary.
 	TEMPORARY_TEXT(P)
 	Tester::expand(A, first, D);
 	Tester::expand(P, second, D);
-	wchar_t P_C_string[1024];
+	inchar32_t P_C_string[1024];
 	Str::copy_to_wide_string(P_C_string, P, 1024);
 	match_results mr = Regexp::create_mr();
 	ENTER_EXECUTION_BLOCK(Regexp::match(&mr, A, P_C_string));
@@ -979,7 +979,7 @@ void Tester::expand(OUTPUT_STREAM, recipe_token *T, dictionary *D) {
 	TEMPORARY_TEXT(unsubstituted)
 	Str::copy(unsubstituted, original);
 	match_results mr = Regexp::create_mr();
-	while (Regexp::match(&mr, unsubstituted, L"(%c*)$$(%i+)(%c*)")) {
+	while (Regexp::match(&mr, unsubstituted, U"(%c*)$$(%i+)(%c*)")) {
 		Str::copy(unsubstituted, mr.exp[0]);
 		filename *F = Globals::to_filename(mr.exp[1]);
 		if (F) {
@@ -987,7 +987,7 @@ void Tester::expand(OUTPUT_STREAM, recipe_token *T, dictionary *D) {
 		}
 		WRITE_TO(unsubstituted, "%S", mr.exp[2]);
 	}
-	while (Regexp::match(&mr, unsubstituted, L"(%c*)$(%i+)(%c*)")) {
+	while (Regexp::match(&mr, unsubstituted, U"(%c*)$(%i+)(%c*)")) {
 		Str::copy(unsubstituted, mr.exp[0]);
 		text_stream *dv = Dictionaries::get_text(D, mr.exp[1]);
 		if (dv) WRITE_TO(unsubstituted, "%S", dv);
@@ -1029,7 +1029,7 @@ to standard output, but |2>'&1'| sends errors to a file literally called |&1|.
 
 @<Apply quotation marks as needed@> =
 	TEMPORARY_TEXT(quoted)
-	wchar_t c = Str::get_first_char(unquoted);
+	inchar32_t c = Str::get_first_char(unquoted);
 	int n = T->token_quoted;
 	if ((c == '>') || (c == '<')) { PUT(c); Str::delete_first_character(unquoted); }
 	else if ((Characters::isdigit(c)) && (Str::get_at(unquoted, 1) == '>')) {
@@ -1106,9 +1106,9 @@ void Tester::read_tokens(text_stream *line_text, text_file_position *tfp, void *
 @<Expand token from hash@> =
 	int z = NOT_APPLICABLE;
 	TEMPORARY_TEXT(name)
-	if (Str::begins_with_wide_string(unquoted, L"zmachine:")) {
+	if (Str::begins_with_wide_string(unquoted, U"zmachine:")) {
 		Str::substr(name, Str::at(unquoted, 9), Str::end(unquoted)); z = TRUE;
-	} else if (Str::begins_with_wide_string(unquoted, L"glulx:")) {
+	} else if (Str::begins_with_wide_string(unquoted, U"glulx:")) {
 		Str::substr(name, Str::at(unquoted, 6), Str::end(unquoted)); z = FALSE;
 	} else {
 		WRITE_TO(name, "%S", unquoted);

--- a/arch-module/Chapter 2/Compatibility.w
+++ b/arch-module/Chapter 2/Compatibility.w
@@ -137,7 +137,7 @@ compatibility_specification *Compatibility::from_text(text_stream *text) {
 		error_in_syntax = TRUE;
 
 @<Parse out the prefix not@> =
-	if (Regexp::match(&mr, parse, L"not (%c+)")) {
+	if (Regexp::match(&mr, parse, U"not (%c+)")) {
 		Str::clear(parse);
 		WRITE_TO(parse, "%S", mr.exp[0]);
 		Str::trim_white_space(parse);
@@ -146,14 +146,14 @@ compatibility_specification *Compatibility::from_text(text_stream *text) {
 	}
 
 @<Remove the meaningless word for@> =
-	if (Regexp::match(&mr, parse, L"for (%c+)")) {
+	if (Regexp::match(&mr, parse, U"for (%c+)")) {
 		Str::clear(parse);
 		WRITE_TO(parse, "%S", mr.exp[0]);
 		Str::trim_white_space(parse);
 	}
 
 @<Parse out the suffix only@> =
-	if (Regexp::match(&mr, parse, L"(%c+) only")) {
+	if (Regexp::match(&mr, parse, U"(%c+) only")) {
 		Str::clear(parse);
 		WRITE_TO(parse, "%S", mr.exp[0]);
 		Str::trim_white_space(parse);
@@ -207,7 +207,7 @@ We end the sequence of tokens with a |NULL|, telling the token-parser that
 it has reached the end.
 
 @<Reduce the text to a sequence of tokens@> =
-	while (Regexp::match(&mr, text, L"(%C+) (%c+)")) {
+	while (Regexp::match(&mr, text, U"(%C+) (%c+)")) {
 		int comma = FALSE;
 		if (Str::get_last_char(mr.exp[0]) == ',') {
 			comma = TRUE;
@@ -231,11 +231,11 @@ trims; and otherwise returns |NOT_APPLICABLE| and leaves |T| unaltered.
 int Compatibility::parse_debugging(text_stream *T) {
 	int with = NOT_APPLICABLE;
 	match_results mr = Regexp::create_mr();
-	if (Regexp::match(&mr, T, L"with debugging,* *(%c*)")) {
+	if (Regexp::match(&mr, T, U"with debugging,* *(%c*)")) {
 		Str::clear(T);
 		Str::copy(T, mr.exp[0]);
 		with = TRUE;
-	} else if (Regexp::match(&mr, T, L"without debugging,* *(%c*)")) {
+	} else if (Regexp::match(&mr, T, U"without debugging,* *(%c*)")) {
 		Str::clear(T);
 		Str::copy(T, mr.exp[0]);
 		with = FALSE;


### PR DESCRIPTION
The current representation of "wide" strings uses wchar_t and L"" literals. This suffers from there being no defined minimum size for each character: on Windows it is commonly 16 bits, which isn't enough for all current Unicode code points.

C11 introduced true 32-bit string representations with char32_t and U"" literals. The type requires the uchar.h header which is not at the moment available on MacOS, so this PR uses U"" literals and an internal type for wide characters, inchar32_t, which is typedefed to uint32_t. It also introduces an EOF marker C32EOF, which is a value that can be assigned to an inchar32_t. (EOF from the C standard library is often defined as -1, which is not suitable for use with an unsigned integer.)